### PR TITLE
fix: Invalid return for Jest config check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ let transformOpts: Options
 
 function getJestTransformConfig(
   jestConfig: JestConfig26 | JestConfig27
-): Options {
+): Options | undefined {
   if ("transformerConfig" in jestConfig) {
     // jest 27
     return jestConfig.transformerConfig;
@@ -25,11 +25,9 @@ function getJestTransformConfig(
     return (
       jestConfig.transform.find(
         ([, transformerPath]) => transformerPath === __filename
-      )?.[2] ?? {}
+      )?.[2]
     );
   }
-
-  return {};
 }
 
 export = {
@@ -42,7 +40,7 @@ export = {
 
         if (!swcOptions) {
           const swcrc = path.join(process.cwd(), '.swcrc')
-          swcOptions = fs.existsSync(swcrc) ? JSON.parse(fs.readFileSync(swcrc, 'utf-8')) : {}
+          swcOptions = fs.existsSync(swcrc) ? JSON.parse(fs.readFileSync(swcrc, 'utf-8')) as Options : {}
         }
 
         // set(swcOptions, 'module.type', 'commonjs')


### PR DESCRIPTION
Changes from #12 introduced a config load error when using `Jest < 27`. The function fallback to returning `{}` in case of missing, and this breaks the `if (!swcOptions) {` checks later on.  Which means using Jest 26 and below, default config does not load your `.swcrc`. This pull request fixed it.

In the meantime for the curious, we fixed it by tricking the null check operator:
```js
module.exports = {
  transform: {
    '^.+\\.(ts|tsx|js|jsx)$': ['@swc/jest', 0],
  },//                                      ^ The zero here passes the null-check
}
```