### PR TITLE
Look up closest package.json

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,8 +13,22 @@ interface JestTransformerOption {
   transformerConfig: Options;
 }
 
-const packagePath = path.join(process.cwd(), 'package.json')
-const packageConfig = JSON.parse(fs.readFileSync(packagePath, 'utf-8'))
+/**
+ * Loads closes package.json in the directory hierarchy
+ */
+function loadClosesPackageJson(attempts = 1): Record<string, unknown> {
+  if (attempts > 5) {
+      throw new Error('Can\'t resolve main package.json file');
+  }
+  var mainPath = attempts === 1 ? './' : Array(attempts).join("../");
+  try {
+      return require(mainPath + 'package.json');
+  } catch (e) {
+      return loadClosesPackageJson(attempts + 1);
+  }
+}
+
+const packageConfig = loadClosesPackageJson()
 const isEsmProject = packageConfig.type === 'module'
 
 // Jest use the `vm` [Module API](https://nodejs.org/api/vm.html#vm_class_vm_module) for ESM.


### PR DESCRIPTION
**Environment:**

In NX Mono-repo setup the directory can look like this:
```

<root>
 | - package.json
 | - jest.preset.json
 | - // other-configs
 | packages
 |    module1
 |    - tsconfig.json
 |     - jest.config.json
 |       src
 |          lib
 |            - class.ts
 |               __tests__
 |                   - class.test.ts
```

**Issue:**

If test is executed from IDE (Webstorm) in this case, the process path is `packages/module1`. Seems like it is because Webstorm tries to find the closest jest configuration. Such behaviour causes the current implementation reading package.json to fail.


**Solution:**

Try to look up the closest package.json file, rather than depending on the existence in the current process path.