### PR TITLE
Remove filename check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -39,11 +39,6 @@ let swcTransformOpts: Options
 
 export = {
   process(src: string, filename: string, jestOptions: any) {
-
-    if (!/\.[jt]sx?$/.test(filename)) {
-      return src
-    }
-
     if (!swcTransformOpts) {
       swcTransformOpts = buildSwcTransformOpts(jestOptions)
     }


### PR DESCRIPTION
Fix #35

Jest users already have to specify a regex of filenames that transformers
should apply to per the usage example in the readme:


```js
module.exports = {
  transform: {
    // this regex here
    '^.+\\.(t|j)sx?$': '@swc/jest',
  },
}
```

There is no value in performing an additional hardcoded check within the transform - it just blocks the transform from running on other filenames that the user may have deemed as being desirable to transform (such as .mjs files).