### PR TITLE
Start package.json lookup in current work dir

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ function loadClosesPackageJson(attempts = 1): Record<string, unknown> {
   }
   var mainPath = attempts === 1 ? './' : Array(attempts).join("../");
   try {
-      return require(mainPath + 'package.json');
+      return require(path.join(process.cwd(), mainPath, 'package.json'));
   } catch (e) {
       return loadClosesPackageJson(attempts + 1);
   }


### PR DESCRIPTION
This fixes `package.json` lookup logic and makes it pick up current project `package.json` (rather than its own `package.json` as it did prior to this change).

Was getting weird issues with the package because of this (ESM detection failed because it always picked up its own non-ESM package rather than one I've worked on)