### PR TITLE
Disable swcrc

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -65,6 +65,7 @@ function buildSwcTransformOpts(swcOptions: any) {
   }
 
   set(swcOptions, 'jsc.transform.hidden.jest', true)
+  set(swcOptions, 'swcrc', false)
 
   return swcOptions
 }


### PR DESCRIPTION
The way (if I'm correct) of `@swc/jest` works, is that it loads the `.swcrc` file, then updates some fields if necessary (like `jsc.transform.hidden.jest = true`), and then passes this corrected object to `@swc/core`'s `transformSync` method.

But if `swcrc: false` isn't set in this object, SWC will still try to load the `.swcrc` file even if the full config is provided, and it isn't able to properly merge the 2 objects, so if `jsc.transform.hidden.jest` wasn't set initially, in the end it gets reset.


This would solve https://github.com/swc-project/jest/issues/14