### PR TITLE
[jest-mock] add test for mocks

### DIFF
--- a/examples/react/src/App.test.tsx
+++ b/examples/react/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { App } from "./App";
-import { create } from 'react-test-renderer'
+import { create } from "react-test-renderer";
 
 it("should work", () => {
   const renderer = create(<App />);
-  expect(renderer.toJSON()).toBeDefined()
+  expect(renderer.toJSON()).toBeDefined();
 });

--- a/examples/react/src/Mock.test.tsx
+++ b/examples/react/src/Mock.test.tsx
@@ -1,0 +1,15 @@
+import { Mock } from "./Mock";
+import { create } from "react-test-renderer";
+
+jest.mock("./to-be-mocked.ts", () => ({
+  toBeMocked: () => "mocked",
+}));
+
+it("should render the app and properly mock files", () => {
+  const renderer = create(<Mock />);
+  expect(renderer.toJSON()).toEqual({
+    type: "div",
+    props: {},
+    children: ["mocked"],
+  });
+});

--- a/examples/react/src/Mock.tsx
+++ b/examples/react/src/Mock.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import { toBeMocked } from "./to-be-mocked";
+
+export function Mock() {
+  return <div>{toBeMocked()}</div>;
+}

--- a/examples/react/src/to-be-mocked.ts
+++ b/examples/react/src/to-be-mocked.ts
@@ -1,0 +1,3 @@
+export function toBeMocked() {
+  return "not-mocked";
+}


### PR DESCRIPTION
Add tests for `jest.mock` to ensure that https://github.com/swc-project/jest/pull/44 really works as expected

Add 3 new files:
- Mock.tsx
- Mock.test.tsx
- to-be-mocked.ts

Mock.tsx imports to-be-mocked.ts, which is mocked in Mock.test.tsx, and in the test, we make sure that the mock is called instead of the original file