### PR TITLE
Reduce minimum npm version to 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "index.js"
   ],
   "engines": {
-    "npm": "^8.0.0"
+    "npm": ">= 7.0.0"
   },
   "workspaces": [
     "examples/*"


### PR DESCRIPTION
`engines.npm` is also read on install by npm, causing warnings like:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@swc/jest@0.2.10',
npm WARN EBADENGINE   required: { npm: '^8.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.6.0', npm: '7.20.3' }
npm WARN EBADENGINE }
```

I don't think npm 8 is required here as it works well on v7 too (other than the warning)