### PR TITLE
feat: remove strict npm version check in the engines field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swc/jest",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swc/jest",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -19,9 +19,6 @@
         "@types/node": "^14.17.14",
         "jest": "^26.4.2",
         "typescript": "^4.0.2"
-      },
-      "engines": {
-        "npm": ">= 7.0.0"
       },
       "peerDependencies": {
         "@swc/core": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swc/jest",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "swc integration for jest",
   "main": "index.js",
   "homepage": "https://github.com/swc-project/jest",
@@ -35,9 +35,6 @@
   "files": [
     "index.js"
   ],
-  "engines": {
-    "npm": ">= 7.0.0"
-  },
   "workspaces": [
     "examples/*"
   ]


### PR DESCRIPTION
Discussion and reason please refer to https://github.com/swc-project/jest/pull/50#issuecomment-991981588
When the PR is merged, we may need to publish this new `0.2.13` to the npm registry.
