### PR TITLE
Small grammar tweaks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ function loadClosestPackageJson(attempts = 1): Record<string, unknown> {
   if (attempts > 5) {
       throw new Error('Can\'t resolve main package.json file');
   }
-  var mainPath = attempts === 1 ? './' : Array(attempts).join("../");
+  const mainPath = attempts === 1 ? './' : Array(attempts).join("../");
   try {
       return require(path.join(process.cwd(), mainPath, 'package.json'));
   } catch (e) {

--- a/index.ts
+++ b/index.ts
@@ -34,14 +34,14 @@ const isEsmProject = packageConfig.type === 'module'
 
 // Jest use the `vm` [Module API](https://nodejs.org/api/vm.html#vm_class_vm_module) for ESM.
 // see https://github.com/facebook/jest/issues/9430
-const isSupportEsm = 'Module' in vm
+const supportsEsm = 'Module' in vm
 
 function createTransformer(swcTransformOpts?: Options) {
   swcTransformOpts = buildSwcTransformOpts(swcTransformOpts)
 
   return {
     process(src: string, filename: string, jestOptions: any) {
-      if (isSupportEsm) {
+      if (supportsEsm) {
         set(swcTransformOpts, 'module.type', isEsm(filename, jestOptions) ? 'es6' : 'commonjs')
       }
 
@@ -60,7 +60,7 @@ function buildSwcTransformOpts(swcOptions: any) {
     swcOptions = fs.existsSync(swcrc) ? JSON.parse(fs.readFileSync(swcrc, 'utf-8')) as Options : {}
   }
 
-  if (!isSupportEsm) {
+  if (!supportsEsm) {
     set(swcOptions, 'module.type', 'commonjs')
   }
 


### PR DESCRIPTION
`isSupportEsm` is not really a valid english and `if(isSupportEsm)` does not read properly, feels awkward

I have changed it to `supportsEsm` which reads properly when doing `if(supportsEsm)`
It can also read properly if renamed to `isEsmSupported` and in `if(isEsmSupported)` also reads like valid english

Also changed a var to const.

I have noticed that code style is a bit inconsistent, like some lines have semicolons and some not.
Would you be interested in having a linter in here?