### PR TITLE
feat: Build & publish type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.21",
   "description": "swc integration for jest",
   "main": "index.js",
+  "types": "index.d.ts",
   "homepage": "https://github.com/swc-project/jest",
   "scripts": {
     "build": "npm run lint && tsc",
@@ -41,7 +42,8 @@
     "npm": ">= 7.0.0"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "workspaces": [
     "examples/react"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true, /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
Hey there, we've instrumented our jest build phases so that we're collecting performance metrics around compilation. To do this, we augment the transform returned by `transformSync`.

By publishing the types of this package, this wrapping code can be written in typescript without adding some global declarations for `@swc/jest`:

i.e. we do something like this:

```
import { createTransformer } from '@swc/jest';
export function createTransformer() {
  const swcTransformer = createTransformer();
  return { ... /* use swcTransformer */ ... };
}
```