### PR TITLE
Support .swcrc files as JSONC

### DIFF
--- a/examples/react/.swcrc
+++ b/examples/react/.swcrc
@@ -1,0 +1,18 @@
+{
+  // .swcrc should be treated as JSONC
+
+  "sourceMaps": true,
+
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true
+    },
+
+    "transform": {
+      "react": {
+        "runtime": "automatic"
+      }
+    }
+  }
+}

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -29,25 +29,7 @@
       "node"
     ],
     "transform": {
-      "^.+\\.(t|j)sx?$": [
-        "@swc/jest",
-        {
-          "sourceMaps": true,
-
-          "jsc": {
-            "parser": {
-              "syntax": "typescript",
-              "tsx": true
-            },
-
-            "transform": {
-              "react": {
-                "runtime": "automatic"
-              }
-            }
-          }
-        }
-      ]
+      "^.+\\.(t|j)sx?$": ["@swc/jest"]
     },
     "testEnvironment": "node"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@swc/jest",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swc/jest",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "workspaces": [
         "examples/react"
       ],
       "dependencies": {
-        "@jest/create-cache-key-function": "^27.4.2"
+        "@jest/create-cache-key-function": "^27.4.2",
+        "jsonc-parser": "^3.2.0"
       },
       "devDependencies": {
         "@jest/transform": "^27.5.1",
@@ -4475,6 +4476,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6789,6 +6795,7 @@
         "eslint": "^8.4.1",
         "examples": "file:examples/react",
         "jest": "^27.4.4",
+        "jsonc-parser": "*",
         "typescript": "^4.5.3"
       },
       "dependencies": {
@@ -10075,6 +10082,11 @@
           "requires": {
             "minimist": "^1.2.5"
           }
+        },
+        "jsonc-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+          "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
         },
         "kleur": {
           "version": "3.0.3",
@@ -13522,6 +13534,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@swc/core": "*"
   },
   "dependencies": {
-    "@jest/create-cache-key-function": "^27.4.2"
+    "@jest/create-cache-key-function": "^27.4.2",
+    "jsonc-parser": "^3.2.0"
   },
   "devDependencies": {
     "@jest/transform": "^27.5.1",


### PR DESCRIPTION
JSONC support for `.swcrc` files was added in https://github.com/swc-project/swc/pull/4236.

This PR updates `@swc/jest` to use `jsonc-parser` instead of `JSON.parse()`.

Fixes #123