### PR TITLE
chore: script workspaces from package.json on publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "npm run lint && tsc",
     "test": "npm test --workspaces",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && node scripts/publish_helper.js prepublish",
+    "postpublish": "node scripts/publish_helper.js postpublish",
     "lint": "eslint . --ext .ts && echo 'No lint errors found!'"
   },
   "keywords": [],

--- a/scripts/publish_helper.js
+++ b/scripts/publish_helper.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+const error = (msg) => {
+  console.error(msg);
+  process.exit(1);
+}
+
+const packagePath = path.join(__dirname, '..', 'package.json');
+const packageBakPath = packagePath + '.bak';
+
+const type = process.argv[2];
+if (type === 'prepublish') {
+  if (fs.existsSync(packageBakPath)) {
+    fs.copyFileSync(packageBakPath, packagePath);
+    fs.unlinkSync(packageBakPath);
+  }
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+  delete packageJson.workspaces;
+  fs.copyFileSync(packagePath, './package.json.bak');
+  fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2));
+} else if (type === 'postpublish') {
+  if (!fs.existsSync(packageBakPath)) {
+    error('package.json.bak not found')
+  }
+  fs.copyFileSync(packageBakPath, packagePath);
+  fs.unlinkSync(packageBakPath);
+} else {
+  error(`invalid type: ${type}. Expected 'prepublish' or 'postpublish'.`);
+}


### PR DESCRIPTION
Closes #101

PR modifies the publish workflow such that a new helper script will be called before publishing to strip out the `workspaces` value in the `package.json` file, and a post publish step that restores the original `package.json` file. This avoids publishing the package with this additional key that causes a warning in `yarn`, but should otherwise not affect any other part of the dev flow.

To test, can run:
```bash
$ npm run prepublishOnly
# should have modified package.json & package.json.bak
$ npm run postpublish
# should only have original package.json
```