### PR TITLE
fix: Allow using `.swcrc` when no option defined

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -105,7 +105,10 @@ const nodeTargetDefaults = new Map([
 
 function buildSwcTransformOpts(swcOptions: (Options & { experimental?: unknown }) | undefined): Options {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { experimental, ...computedSwcOptions } = swcOptions || (getOptionsFromSwrc() as Options & { experimental?: unknown })
+  const { experimental, ...computedSwcOptions } =
+    swcOptions && Object.keys(swcOptions).length > 0
+      ? swcOptions
+      : getOptionsFromSwrc() as Options & { experimental?: unknown }
 
   if (!computedSwcOptions.env && !computedSwcOptions.jsc?.target) {
     set(


### PR DESCRIPTION
I am using jest `29.7.0` ([config](https://github.com/foray1010/Popup-my-Bookmarks/blob/master/jest.config.mjs#L11)) and I keep getting error `env and jsc.target cannot be used together` using this [.swcrc](https://github.com/foray1010/Popup-my-Bookmarks/blob/master/.swcrc). And by digging into the source code I found that the `swcTransformOpts` is `{}` in [the beginning](https://github.com/swc-project/jest/blob/master/index.ts#L23), thus `swcOptions || getOptionsFromSwrc()` never works.