### PR TITLE
feat: Switch from using md5 to sha1

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ function createTransformer(swcTransformOpts?: Options & {
       const options: TransformOptions = typeof rest[0] === 'string' ? rest[1] : rest[0]
 
       return crypto
-        .createHash('md5')
+        .createHash('sha1')
         .update(baseCacheKey)
         .update('\0', 'utf8')
         .update(JSON.stringify({ supportsStaticESM: options.supportsStaticESM }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@swc/jest",
-  "version": "0.2.23",
+  "version": "0.2.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swc/jest",
-      "version": "0.2.23",
+      "version": "0.2.29",
       "license": "MIT",
       "workspaces": [
         "examples/react"
       ],
       "dependencies": {
-        "@jest/create-cache-key-function": "^27.4.2",
+        "@jest/create-cache-key-function": "^29.7.0",
         "jsonc-parser": "^3.2.0"
       },
       "devDependencies": {
@@ -798,14 +798,38 @@
       }
     },
     "node_modules/@jest/create-cache-key-function": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
-      "integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
       "dependencies": {
-        "@jest/types": "^27.5.1"
+        "@jest/types": "^29.6.3"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/create-cache-key-function/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/create-cache-key-function/node_modules/@types/yargs": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dependencies": {
+        "@types/yargs-parser": "*"
       }
     },
     "node_modules/@jest/environment": {
@@ -898,6 +922,17 @@
         }
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/source-map": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
@@ -972,6 +1007,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
       "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -1042,6 +1078,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -1448,6 +1489,7 @@
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -6458,11 +6500,34 @@
       }
     },
     "@jest/create-cache-key-function": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
-      "integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
       "requires": {
-        "@jest/types": "^27.5.1"
+        "@jest/types": "^29.6.3"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+          "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+          "requires": {
+            "@jest/schemas": "^29.6.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.32",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+          "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        }
       }
     },
     "@jest/environment": {
@@ -6535,6 +6600,14 @@
         "v8-to-istanbul": "^8.1.0"
       }
     },
+    "@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "requires": {
+        "@sinclair/typebox": "^0.27.8"
+      }
+    },
     "@jest/source-map": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
@@ -6597,6 +6670,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
       "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
@@ -6652,6 +6726,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -6786,7 +6865,7 @@
     "@swc/jest": {
       "version": "file:",
       "requires": {
-        "@jest/create-cache-key-function": "^27.4.2",
+        "@jest/create-cache-key-function": "^29.7.0",
         "@jest/transform": "^27.5.1",
         "@swc/core": "^1.2.177",
         "@types/node": "^16.11.12",
@@ -6795,7 +6874,7 @@
         "eslint": "^8.4.1",
         "examples": "file:examples/react",
         "jest": "^27.4.4",
-        "jsonc-parser": "*",
+        "jsonc-parser": "^3.2.0",
         "typescript": "^4.5.3"
       },
       "dependencies": {
@@ -7366,11 +7445,34 @@
           }
         },
         "@jest/create-cache-key-function": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
-          "integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+          "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
           "requires": {
-            "@jest/types": "^27.5.1"
+            "@jest/types": "^29.6.3"
+          },
+          "dependencies": {
+            "@jest/types": {
+              "version": "29.6.3",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+              "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+              "requires": {
+                "@jest/schemas": "^29.6.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^17.0.8",
+                "chalk": "^4.0.0"
+              }
+            },
+            "@types/yargs": {
+              "version": "17.0.32",
+              "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+              "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+              "requires": {
+                "@types/yargs-parser": "*"
+              }
+            }
           }
         },
         "@jest/environment": {
@@ -7443,6 +7545,14 @@
             "v8-to-istanbul": "^8.1.0"
           }
         },
+        "@jest/schemas": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+          "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+          "requires": {
+            "@sinclair/typebox": "^0.27.8"
+          }
+        },
         "@jest/source-map": {
           "version": "27.5.1",
           "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
@@ -7505,6 +7615,7 @@
           "version": "27.5.1",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
           "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+          "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
@@ -7560,6 +7671,11 @@
             "@nodelib/fs.scandir": "2.1.5",
             "fastq": "^1.6.0"
           }
+        },
+        "@sinclair/typebox": {
+          "version": "0.27.8",
+          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+          "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
         },
         "@sinonjs/commons": {
           "version": "1.8.3",
@@ -7829,6 +7945,7 @@
         },
         "@types/yargs": {
           "version": "16.0.4",
+          "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -11281,6 +11398,7 @@
     },
     "@types/yargs": {
       "version": "16.0.4",
+      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@swc/core": "*"
   },
   "dependencies": {
-    "@jest/create-cache-key-function": "^27.4.2",
+    "@jest/create-cache-key-function": "^29.7.0",
     "jsonc-parser": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
updated jest package is using sha1.
This makes it easier to run on FIPS systems.